### PR TITLE
Fix mermaid inclusion in Mardown as well as couple of mermaid fixes

### DIFF
--- a/custom_modes/creative_instructions.md
+++ b/custom_modes/creative_instructions.md
@@ -2,7 +2,7 @@
 
 Your role is to perform detailed design and architecture work for components flagged during the planning phase.
 
-<mermaid>
+```mermaid
 graph TD
     Start["🚀 START CREATIVE MODE"] --> ReadTasks["📚 Read tasks.md &<br>implementation-plan.md<br>.cursor/rules/isolation_rules/main.mdc"]
     
@@ -71,7 +71,7 @@ graph TD
     style MoreComponents fill:#d94dbb,stroke:#a3378a,color:white
     style VerifyAll fill:#4dbbbb,stroke:#368787,color:white
     style Transition fill:#5fd94d,stroke:#3da336,color:white
-</mermaid> 
+```
 
 ## IMPLEMENTATION STEPS
 
@@ -149,7 +149,7 @@ Your task is to generate multiple design options for components flagged during p
 
 When working on architectural components, focus on defining the system structure, component relationships, and technical foundations. Generate multiple architectural approaches and evaluate each against requirements.
 
-<mermaid>
+```mermaid
 graph TD
     AD["🏗️ ARCHITECTURE DESIGN"] --> Req["Define requirements & constraints"]
     Req --> Options["Generate 2-4 architecture options"]
@@ -167,13 +167,13 @@ graph TD
     style Eval fill:#cce6ff,stroke:#80bfff
     style Select fill:#cce6ff,stroke:#80bfff
     style Doc fill:#cce6ff,stroke:#80bfff
-</mermaid>
+```
 
 ### Algorithm Design Process
 
 For algorithm components, focus on efficiency, correctness, and maintainability. Consider time and space complexity, edge cases, and scalability when evaluating different approaches.
 
-<mermaid>
+```mermaid
 graph TD
     ALGO["⚙️ ALGORITHM DESIGN"] --> Req["Define requirements & constraints"]
     Req --> Options["Generate 2-4 algorithm options"]
@@ -195,13 +195,13 @@ graph TD
     style Scale fill:#d6f5dd,stroke:#a3e0ae
     style Select fill:#d6f5dd,stroke:#a3e0ae
     style Doc fill:#d6f5dd,stroke:#a3e0ae
-</mermaid>
+```
 
 ### UI/UX Design Process
 
 For UI/UX components, focus on user experience, accessibility, consistency with design patterns, and visual clarity. Consider different interaction models and layouts when exploring options.
 
-<mermaid>
+```mermaid
 graph TD
     UIUX["🎨 UI/UX DESIGN"] --> Req["Define requirements & user needs"]
     Req --> Options["Generate 2-4 design options"]
@@ -223,13 +223,13 @@ graph TD
     style Comp fill:#ffe6cc,stroke:#ffa64d
     style Select fill:#ffe6cc,stroke:#ffa64d
     style Doc fill:#ffe6cc,stroke:#ffa64d
-</mermaid>
+```
 
 ## CREATIVE PHASE DOCUMENTATION
 
 Document each creative phase with clear entry and exit markers. Start by describing the component and its requirements, then explore multiple options with their pros and cons, and conclude with a recommended approach and implementation guidelines.
 
-<mermaid>
+```mermaid
 graph TD
     CPD["🎨 CREATIVE PHASE DOCUMENTATION"] --> Entry["🎨🎨🎨 ENTERING CREATIVE PHASE: [TYPE]"]
     Entry --> Desc["Component Description<br>What is this component? What does it do?"]
@@ -251,11 +251,11 @@ graph TD
     style Impl fill:#f5d9f0,stroke:#e699d9
     style Verify fill:#f5d9f0,stroke:#e699d9
     style Exit fill:#f5d9f0,stroke:#e699d9
-</mermaid>
+```
 
 ## VERIFICATION
 
-<mermaid>
+```mermaid
 graph TD
     V["✅ VERIFICATION CHECKLIST"] --> C["All flagged components addressed?"]
     V --> O["Multiple options explored for each component?"]
@@ -272,6 +272,6 @@ graph TD
     style Decision fill:#ffa64d,stroke:#cc7a30,color:white
     style Complete fill:#5fd94d,stroke:#3da336,color:white
     style Fix fill:#ff5555,stroke:#cc0000,color:white
-</mermaid>
+```
 
 Before completing the creative phase, verify that all flagged components have been addressed with multiple options explored, pros and cons analyzed, recommendations justified, and implementation guidelines provided. Update tasks.md with the design decisions and prepare for the implementation phase. 

--- a/custom_modes/implement_instructions.md
+++ b/custom_modes/implement_instructions.md
@@ -2,7 +2,7 @@
 
 Your role is to build the planned changes following the implementation plan and creative phase decisions.
 
-<mermaid>
+```mermaid
 graph TD
     Start["🚀 START BUILD MODE"] --> ReadDocs["📚 Read Reference Documents<br>.cursor/rules/isolation_rules/Core/command-execution.mdc"]
     
@@ -66,7 +66,7 @@ graph TD
     style CommandExec fill:#d971ff,stroke:#a33bc2,color:white
     style VerifyComplete fill:#4dbbbb,stroke:#368787,color:white
     style Transition fill:#5fd94d,stroke:#3da336,color:white
-</mermaid>
+```
 
 ## BUILD STEPS
 
@@ -139,7 +139,7 @@ Your task is to build the changes defined in the implementation plan, following 
 
 For Level 1 tasks, focus on implementing targeted fixes for specific issues. Understand the bug, examine the relevant code, implement a precise fix, and verify that the issue is resolved.
 
-<mermaid>
+```mermaid
 graph TD
     L1["🔧 LEVEL 1 BUILD"] --> Review["Review the issue carefully"]
     Review --> Locate["Locate specific code causing the issue"]
@@ -153,13 +153,13 @@ graph TD
     style Fix fill:#d6f5dd,stroke:#a3e0ae
     style Test fill:#d6f5dd,stroke:#a3e0ae
     style Doc fill:#d6f5dd,stroke:#a3e0ae
-</mermaid>
+```
 
 ### Level 2: Enhancement Build
 
 For Level 2 tasks, implement changes according to the plan created during the planning phase. Ensure each step is completed and tested before moving to the next, maintaining clarity and focus throughout the process.
 
-<mermaid>
+```mermaid
 graph TD
     L2["🔨 LEVEL 2 BUILD"] --> Plan["Follow build plan"]
     Plan --> Components["Build each component"]
@@ -173,13 +173,13 @@ graph TD
     style Test fill:#ffe6cc,stroke:#ffa64d
     style Integration fill:#ffe6cc,stroke:#ffa64d
     style Doc fill:#ffe6cc,stroke:#ffa64d
-</mermaid>
+```
 
 ### Level 3-4: Phased Build
 
 For Level 3-4 tasks, implement using a phased approach as defined in the implementation plan. Each phase should be built, tested, and documented before proceeding to the next, with careful attention to integration between components.
 
-<mermaid>
+```mermaid
 graph TD
     L34["🏗️ LEVEL 3-4 BUILD"] --> CreativeReview["Review creative phase decisions"]
     CreativeReview --> Phases["Build in planned phases"]
@@ -197,13 +197,13 @@ graph TD
     style Phase3 fill:#ffaaaa,stroke:#ff8080
     style Test fill:#ffaaaa,stroke:#ff8080
     style Doc fill:#ffaaaa,stroke:#ff8080
-</mermaid>
+```
 
 ## COMMAND EXECUTION PRINCIPLES
 
 When building changes, follow these command execution principles for optimal results:
 
-<mermaid>
+```mermaid
 graph TD
     CEP["⚙️ COMMAND EXECUTION PRINCIPLES"] --> Context["Provide context for each command"]
     CEP --> Platform["Adapt commands for platform"]
@@ -215,13 +215,13 @@ graph TD
     style Platform fill:#e6b3ff,stroke:#d971ff
     style Documentation fill:#e6b3ff,stroke:#d971ff
     style Testing fill:#e6b3ff,stroke:#d971ff
-</mermaid>
+```
 
 Focus on effective building while adapting your approach to the platform environment. Trust your capabilities to execute appropriate commands for the current system without excessive prescriptive guidance.
 
 ## VERIFICATION
 
-<mermaid>
+```mermaid
 graph TD
     V["✅ VERIFICATION CHECKLIST"] --> I["All build steps completed?"]
     V --> T["Changes thoroughly tested?"]
@@ -237,6 +237,6 @@ graph TD
     style Decision fill:#ffa64d,stroke:#cc7a30,color:white
     style Complete fill:#5fd94d,stroke:#3da336,color:white
     style Fix fill:#ff5555,stroke:#cc0000,color:white
-</mermaid>
+```
 
 Before completing the build phase, verify that all build steps have been completed, changes have been thoroughly tested, the build meets all requirements, details have been documented, and tasks.md has been updated with the current status. Once verified, prepare for the reflection phase. 

--- a/custom_modes/plan_instructions.md
+++ b/custom_modes/plan_instructions.md
@@ -2,7 +2,7 @@
 
 Your role is to create a detailed plan for task execution based on the complexity level determined in the INITIALIZATION mode.
 
-<mermaid>
+```mermaid
 graph TD
     Start["🚀 START PLANNING"] --> ReadTasks["📚 Read tasks.md<br>.cursor/rules/isolation_rules/main.mdc"]
     
@@ -65,7 +65,7 @@ graph TD
     style CheckCreative fill:#d971ff,stroke:#a33bc2,color:white
     style RecCreative fill:#ffa64d,stroke:#cc7a30
     style RecImplement fill:#4dbb5f,stroke:#36873f
-</mermaid>
+```
 
 ## IMPLEMENTATION STEPS
 
@@ -135,7 +135,7 @@ Create a detailed implementation plan based on the complexity level determined d
 
 For Level 2 tasks, focus on creating a streamlined plan that identifies the specific changes needed and any potential challenges. Review the codebase structure to understand the areas affected by the enhancement and document a straightforward implementation approach.
 
-<mermaid>
+```mermaid
 graph TD
     L2["📝 LEVEL 2 PLANNING"] --> Doc["Document plan with these components:"]
     Doc --> OV["📋 Overview of changes"]
@@ -151,13 +151,13 @@ graph TD
     style IS fill:#cce6ff,stroke:#80bfff
     style PC fill:#cce6ff,stroke:#80bfff
     style TS fill:#cce6ff,stroke:#80bfff
-</mermaid>
+```mermaid
 
 ### Level 3-4: Comprehensive Planning
 
 For Level 3-4 tasks, develop a comprehensive plan that addresses architecture, dependencies, and integration points. Identify components requiring creative phases and document detailed requirements. For Level 4 tasks, include architectural diagrams and propose a phased implementation approach.
 
-<mermaid>
+```mermaid
 graph TD
     L34["📊 LEVEL 3-4 PLANNING"] --> Doc["Document plan with these components:"]
     Doc --> RA["📋 Requirements analysis"]
@@ -179,11 +179,11 @@ graph TD
     style DP fill:#ffe6cc,stroke:#ffa64d
     style CM fill:#ffe6cc,stroke:#ffa64d
     style CP fill:#ffe6cc,stroke:#ffa64d
-</mermaid>
+```
 
 ## CREATIVE PHASE IDENTIFICATION
 
-<mermaid>
+```mermaid
 graph TD
     CPI["🎨 CREATIVE PHASE IDENTIFICATION"] --> Question{"Does the component require<br>design decisions?"}
     Question -->|"Yes"| Identify["Flag for Creative Phase"]
@@ -199,13 +199,13 @@ graph TD
     style Identify fill:#ffa64d,stroke:#cc7a30
     style Skip fill:#4dbb5f,stroke:#36873f
     style Types fill:#ffe6cc,stroke:#ffa64d
-</mermaid>
+```
 
 Identify components that require creative problem-solving or significant design decisions. For these components, flag them for the CREATIVE mode. Focus on architectural considerations, algorithm design needs, or UI/UX requirements that would benefit from structured design exploration.
 
 ## VERIFICATION
 
-<mermaid>
+```mermaid
 graph TD
     V["✅ VERIFICATION CHECKLIST"] --> P["Plan addresses all requirements?"]
     V --> C["Components requiring creative phases identified?"]
@@ -220,6 +220,6 @@ graph TD
     style Decision fill:#ffa64d,stroke:#cc7a30,color:white
     style Complete fill:#5fd94d,stroke:#3da336,color:white
     style Fix fill:#ff5555,stroke:#cc0000,color:white
-</mermaid>
+```
 
 Before completing the planning phase, verify that all requirements are addressed in the plan, components requiring creative phases are identified, implementation steps are clearly defined, and dependencies and challenges are documented. Update tasks.md with the complete plan and recommend the appropriate next mode based on whether creative phases are required. 

--- a/custom_modes/plan_instructions.md
+++ b/custom_modes/plan_instructions.md
@@ -151,7 +151,7 @@ graph TD
     style IS fill:#cce6ff,stroke:#80bfff
     style PC fill:#cce6ff,stroke:#80bfff
     style TS fill:#cce6ff,stroke:#80bfff
-```mermaid
+```
 
 ### Level 3-4: Comprehensive Planning
 

--- a/custom_modes/van_instructions.md
+++ b/custom_modes/van_instructions.md
@@ -176,7 +176,9 @@ flowchart TD
     AC --> Tasks([tasks.md])
 
     style PB fill:#f9d77e,stroke:#d9b95c
-    style PC, SP, TC fill:#a8d5ff,stroke:#88b5e0
+    style PC fill:#a8d5ff,stroke:#88b5e0
+    style SP fill:#a8d5ff,stroke:#88b5e0
+    style TC fill:#a8d5ff,stroke:#88b5e0
     style AC fill:#c5e8b7,stroke:#a5c897
     style P fill:#f4b8c4,stroke:#d498a4
     style Tasks fill:#f4b8c4,stroke:#d498a4,stroke-width:3px

--- a/custom_modes/van_instructions.md
+++ b/custom_modes/van_instructions.md
@@ -176,7 +176,7 @@ flowchart TD
     AC --> Tasks([tasks.md])
 
     style PB fill:#f9d77e,stroke:#d9b95c
-    style PC & SP & TC fill:#a8d5ff,stroke:#88b5e0
+    style PC, SP, TC fill:#a8d5ff,stroke:#88b5e0
     style AC fill:#c5e8b7,stroke:#a5c897
     style P fill:#f4b8c4,stroke:#d498a4
     style Tasks fill:#f4b8c4,stroke:#d498a4,stroke-width:3px


### PR DESCRIPTION
- mermaid diagrams where inserted using `<mermaid></mermaid>` instead of the triple backtick option
- there was some errors related to mermaid (separator to style several nodes at once is `,` not `&`)