### PR TITLE
Create memory-bank-paths.mdc which forces agent to adhere to memory-bank folder

### DIFF
--- a/.cursor/rules/isolation_rules/Core/memory-bank-paths.mdc
+++ b/.cursor/rules/isolation_rules/Core/memory-bank-paths.mdc
@@ -8,7 +8,7 @@ alwaysApply: true
 
 **CRITICAL:** All core Memory Bank files reside within the `memory-bank/` directory at the project root. Do NOT create or modify these files outside this directory unless explicitly instructed for archiving purposes.
 
-* **Tasks File:** `memory-bank/tasks.md`
+* **Tasks File:** `memory-bank/tasks.md` - This file is used for active, in-progress task tracking, detailing steps, checklists, and component lists. Its content, particularly the detailed checklists, is merged into the main archive document for the task upon completion. After archival, `tasks.md` is cleared to be ready for the next task. It is an ephemeral working document during a task's lifecycle, with its persistent record captured in the task's archive file.
 * **Active Context File:** `memory-bank/activeContext.md`
 * **Progress File:** `memory-bank/progress.md`
 * **Project Brief File:** `memory-bank/projectbrief.md`
@@ -16,8 +16,8 @@ alwaysApply: true
 * **System Patterns File:** `memory-bank/systemPatterns.md`
 * **Tech Context File:** `memory-bank/techContext.md`
 * **Style Guide File:** `memory-bank/style-guide.md`
-* **Creative Phase Docs:** `memory-bank/creative-[feature_name].md` (or similar convention)
+* **Creative Phase Docs:** `memory-bank/creative/creative-[feature_name].md`
 * **Reflection Docs:** `memory-bank/reflection/reflection-[task_id].md`
-* **Archive Directory:** `memory-bank/archive/`
+* **Archive Directory:** `memory-bank/archive/archive-[task_id].md`
 
 **Verification Mandate:** Before any `create_file` or `edit_file` operation on these core files, verify the path starts with `memory-bank/`. If attempting to create a new core file (e.g., `tasks.md` at the start of a project), ensure it is created at `memory-bank/tasks.md`.

--- a/.cursor/rules/isolation_rules/Core/memory-bank-paths.mdc
+++ b/.cursor/rules/isolation_rules/Core/memory-bank-paths.mdc
@@ -1,0 +1,23 @@
+---
+description: Defines canonical paths for core Memory Bank files.
+globs: memory-bank-paths.mdc
+alwaysApply: true
+---
+
+# CORE MEMORY BANK FILE LOCATIONS
+
+**CRITICAL:** All core Memory Bank files reside within the `memory-bank/` directory at the project root. Do NOT create or modify these files outside this directory unless explicitly instructed for archiving purposes.
+
+* **Tasks File:** `memory-bank/tasks.md`
+* **Active Context File:** `memory-bank/activeContext.md`
+* **Progress File:** `memory-bank/progress.md`
+* **Project Brief File:** `memory-bank/projectbrief.md`
+* **Product Context File:** `memory-bank/productContext.md`
+* **System Patterns File:** `memory-bank/systemPatterns.md`
+* **Tech Context File:** `memory-bank/techContext.md`
+* **Style Guide File:** `memory-bank/style-guide.md`
+* **Creative Phase Docs:** `memory-bank/creative-[feature_name].md` (or similar convention)
+* **Reflection Docs:** `memory-bank/reflection/reflection-[task_id].md`
+* **Archive Directory:** `memory-bank/archive/`
+
+**Verification Mandate:** Before any `create_file` or `edit_file` operation on these core files, verify the path starts with `memory-bank/`. If attempting to create a new core file (e.g., `tasks.md` at the start of a project), ensure it is created at `memory-bank/tasks.md`.


### PR DESCRIPTION
Ran into issues of different agents creating new memory-bank files in root and subdirectories of project. Implemented this and it seems to adhere to structure much better