### PR TITLE
fix: wrong filename when referring `archive-....mdc` in `archive-mode-map.mdc`

### DIFF
--- a/.cursor/rules/isolation_rules/visual-maps/archive-mode-map.mdc
+++ b/.cursor/rules/isolation_rules/visual-maps/archive-mode-map.mdc
@@ -20,10 +20,10 @@ graph TD
     VerifyReflect -->|"Yes"| AssessLevel{"Determine<br>Complexity Level"}
     
     %% Level-Based Archiving
-    AssessLevel -->|"Level 1"| L1Archive["LEVEL 1 ARCHIVING<br>Level1/archive-minimal.md"]
-    AssessLevel -->|"Level 2"| L2Archive["LEVEL 2 ARCHIVING<br>Level2/archive-basic.md"]
-    AssessLevel -->|"Level 3"| L3Archive["LEVEL 3 ARCHIVING<br>Level3/archive-standard.md"]
-    AssessLevel -->|"Level 4"| L4Archive["LEVEL 4 ARCHIVING<br>Level4/archive-comprehensive.md"]
+    AssessLevel -->|"Level 1"| L1Archive["LEVEL 1 ARCHIVING"]
+    AssessLevel -->|"Level 2"| L2Archive["LEVEL 2 ARCHIVING<br>Level2/archive-basic.mdc"]
+    AssessLevel -->|"Level 3"| L3Archive["LEVEL 3 ARCHIVING<br>Level3/archive-intermediate.mdc"]
+    AssessLevel -->|"Level 4"| L4Archive["LEVEL 4 ARCHIVING<br>Level4/archive-comprehensive.mdc"]
     
     %% Level 1 Archiving (Minimal)
     L1Archive --> L1Summary["Create Quick<br>Summary"]


### PR DESCRIPTION
This pull request updates the archive mode map in `.cursor/rules/isolation_rules/visual-maps/archive-mode-map.mdc` to improve the accuracy and consistency of the archiving level references. The main changes are focused on updating the file names and display text for each complexity level in the visual map.

**Visual map updates:**
* Updated the display text and linked file names for each archiving level:
  - Level 1 now omits the file name reference.
  - Level 2 now references `Level2/archive-basic.mdc` instead of `.md`.
  - Level 3 now references `Level3/archive-intermediate.mdc` instead of `archive-standard.md`.
  - Level 4 now references `Level4/archive-comprehensive.mdc` instead of `.md`.