### PR TITLE
Fix missing visual map reference in build.md

### DIFF
--- a/.cursor/commands/build.md
+++ b/.cursor/commands/build.md
@@ -24,7 +24,7 @@ Load: .cursor/rules/isolation_rules/Core/command-execution.mdc
 
 ### Step 2: Load BUILD Mode Map
 ```
-Load: .cursor/rules/isolation_rules/visual-maps/implement-mode-map.mdc
+Load: .cursor/rules/isolation_rules/visual-maps/build-mode-map.mdc
 ```
 
 ### Step 3: Load Complexity-Specific Implementation Rules


### PR DESCRIPTION
The build command referenced `implement-mode-map.mdc` which doesn't exist.
Changed to reference `build-mode-map.mdc` which is the correct file that
exists and follows the naming convention used by other modes.

Fixes #45